### PR TITLE
Add Awesome AI Startups to Related Lists

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Blue
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Blue
+Copyright (c) 2025 Best of AI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ This repository serves as your go-to guide for **AI tools that are actively main
 ### Image & Video Generation
 
 - [**Midjourney v7**](https://www.midjourney.com/) – Premier text-to-image engine (note: official domain; adjust if needed).  
-- [**Adobe Firefly**](https://www.adobe.com/products/firefly.html) – Creative Cloud’s AI image and generative art suite.  
+- [**DALL-E 3**](https://openai.com/dall-e-3) – OpenAI's advanced text-to-image model with precise prompt adherence and integrated ChatGPT access.  
+- [**Adobe Firefly**](https://www.adobe.com/products/firefly.html) – Creative Cloud's AI image and generative art suite.  
 - [**Google Veo 3**](https://gemini.google.com/subscriptions/) – Google’s advanced text-to-video model (accessible via Gemini plans).  
 - [**Runway Gen-4**](https://runwayml.com/) – Cinematic-quality AI video generation platform.  
 - [**Leonardo AI**](https://leonardo.ai/) – Ideal for stylized illustrations and game assets.  
@@ -61,6 +62,7 @@ This repository serves as your go-to guide for **AI tools that are actively main
 
 - [**GitHub Copilot**](https://github.com/features/copilot) – AI pair-programming tool integrated into GitHub.  
 - [**Cursor**](https://cursor.so/) – AI-first programming environment.  
+- [**Vercel v0**](https://v0.dev/) – AI-powered UI component generation with instant deployment capabilities.  
 - [**Aider**](https://aider.ai/) – Terminal-based code assistant.  
 - [**Claude Code**](https://www.anthropic.com/claude) – Anthropic’s developer-targeted version of Claude.  
 - [**Windsurf (Codeium)**](https://codeium.com/) – AI-powered coding IDE.  
@@ -68,13 +70,15 @@ This repository serves as your go-to guide for **AI tools that are actively main
 - [**Vibecode**](https://vibecode.ai/) – Build iOS apps via natural language (powered by modern LLMs).  
 - [**Replit Ghostwriter**](https://replit.com/) – AI tools for live online code collaboration.  
 - [**Sourcegraph Cody**](https://about.sourcegraph.com/cody) – AI assistant for navigating large codebases.  
-- [**Tabnine**](https://www.tabnine.com/) – Privacy-focused code autocompletion.
+- [**Tabnine**](https://www.tabnine.com/) – Privacy-focused code autocompletion.  
+- [**Warp Terminal**](https://www.warp.dev/) – AI-enhanced terminal wrapper for macOS with intelligent features (use defensively).
 
 ---
 
 ### Productivity & Knowledge
 
 - [**Notion AI**](https://www.notion.so/product/ai) – AI-enhanced workspace for writing and projects.  
+- [**Obsidian**](https://obsidian.md/) – AI-enhanced features for the popular markdown-based knowledge management system.  
 - [**Mem AI**](https://mem.ai/) – AI personal knowledge management.  
 - [**Recall**](https://www.recall.ai/) – Learning assistant with summaries and quizzes.  
 - [**Otter.ai**](https://otter.ai/) – Transcription and meeting summarization.  
@@ -129,7 +133,9 @@ This repository serves as your go-to guide for **AI tools that are actively main
 - [**ComfyUI**](https://comfyui.com/) – Node-based interface for Stable Diffusion workflows.  
 - [**Whisper**](https://openai.com/research/whisper) – OpenAI’s speech-to-text model.  
 - [**LangChain**](https://python.langchain.com/) – Framework for building LLM apps.  
+- [**Hugging Face Transformers**](https://huggingface.co/transformers) – Essential library for working with state-of-the-art transformer models.  
 - [**Ollama**](https://ollama.ai/) – Local deployment of AI models with one-line setup.  
+- [**Anaconda**](https://www.anaconda.com/) – Complete Python/R distribution for data science and AI development, including AI Navigator and Anaconda Toolbox with easy Jupyter notebook creation.  
 - [**Open Interpreter**](https://github.com/openai/open-interpreter) – Natural-language interface for controlling your computer.
 
 ---

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This repository serves as your go-to guide for **AI tools that are actively main
 - [**CivitAI**](https://civitai.com/) – Community hub for Stable Diffusion model sharing.  
 - [**Magnific AI**](https://magnific.ai/) – Image upscaler and detail enhancer.  
 - [**Kaiber**](https://kaiber.ai/) – AI animation and music video creation tool.
+- [**Animated Drawings**](https://sketch.metademolab.com/canvas) – Animating children's drawings of characters.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This repository serves as your go-to guide for **AI tools that are actively main
 - [**Pi (Inflection AI)**](https://pi.ai/) – Empathetic conversational AI designed for “personal intelligence.”  
 - [**You.com**](https://you.com/) – Enterprise AI platform offering search, chat, and productivity tools.  
 - [**Quora Poe**](https://poe.com/) – Unified access to multiple AI models from one interface.
+- [**Qwen AI**]((https://chat.qwen.ai/)) – Qwen AI is a free chat-based AI platform that offers generous token limits.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repository serves as your go-to guide for **AI tools that are actively main
 - [**Pi (Inflection AI)**](https://pi.ai/) – Empathetic conversational AI designed for “personal intelligence.”  
 - [**You.com**](https://you.com/) – Enterprise AI platform offering search, chat, and productivity tools.  
 - [**Quora Poe**](https://poe.com/) – Unified access to multiple AI models from one interface.
-- [**Qwen AI**]((https://chat.qwen.ai/)) – Qwen AI is a free chat-based AI platform that offers generous token limits.
+- [**Qwen AI**](https://chat.qwen.ai/) – Qwen AI is a free chat-based AI platform that offers generous token limits.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ This repository serves as your go-to guide for **AI tools that are actively main
 - [**Taskade AI**](https://www.taskade.com/) – Project management with AI workflows.  
 - [**Slite AI**](https://slite.com/) – Team docs with AI-powered summaries.  
 - [**Superhuman AI**](https://superhuman.com/) – Speedy, intelligent email management.
+- [**Gamma**](https://gamma.app/) – AI-powered platform for creating presentations, documents, and webpages with intelligent design and fast workflows.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ Submit a **Pull Request** or open an **Issue** — include name, category, short
 
 ## Related Lists
 
-- [**Awesome AI Tools**](https://github.com/mahseema/awesome-ai-tools) – A broad inventory of AI tools across domains.  
+- [**Awesome AI Tools**](https://github.com/mahseema/awesome-ai-tools) – A broad inventory of AI tools across domains.
+- [**AI For Developer**](https://aifordevelopers.org) - a curated ranked list of ai tools for developers
 - [**Awesome AI Coding Tools**](https://github.com/ai-for-developers/awesome-ai-coding-tools) – Focused on AI in software development.  
 - [**Top AI Directories**](https://github.com/best-of-ai/ai-directories) – Curated directories for discovering AI tools.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This repository serves as your go-to guide for **AI tools that are actively main
 - [**Sourcegraph Cody**](https://about.sourcegraph.com/cody) – AI assistant for navigating large codebases.  
 - [**Tabnine**](https://www.tabnine.com/) – Privacy-focused code autocompletion.  
 - [**Warp Terminal**](https://www.warp.dev/) – AI-enhanced terminal wrapper for macOS with intelligent features (use defensively).
+- [**Kiro**](https://www.kiro.dev/) – Task-based AI IDE that brings structure to AI coding with spec-driven development.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,164 @@
+# Best of AI
+  
+> A hand-picked, regularly updated collection of **the best AI tools currently active** — spanning generative models, productivity enhancements, developer platforms, creative engines, autonomous agents, research aides, and more.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)  
+2. [AI Tools by Category](#ai-tools-by-category)  
+   - [Writing & General AI Assistants](#writing--general-ai-assistants)  
+   - [Image & Video Generation](#image--video-generation)  
+   - [Coding & App Builders](#coding--app-builders)  
+   - [Productivity & Knowledge](#productivity--knowledge)  
+   - [Voice & Music](#voice--music)  
+   - [Automation & Integrations](#automation--integrations)  
+   - [Data, Research & Analysis](#data-research--analysis)  
+   - [Open-Source AI Models & Frameworks](#open-source-ai-models--frameworks)  
+3. [Why These Tools?](#why-these-tools)  
+4. [Contributing](#contributing)  
+5. [Related Lists](#related-lists)  
+6. [License](#license)  
+
+---
+
+## Overview
+
+This repository serves as your go-to guide for **AI tools that are actively maintained and widely adopted in 2025**, carefully curated based on impact, innovation, and community feedback.
+
+---
+
+## AI Tools by Category
+
+### Writing & General AI Assistants
+
+- [**ChatGPT (GPT-5)**](https://openai.com/chatgpt/overview) – OpenAI’s flagship model delivering dynamic model routing for optimized, low-hallucination responses.  
+- [**Claude 3.5 / Opus**](https://www.anthropic.com/claude) – Anthropic’s advanced assistant with deep reasoning and large context support.  
+- [**Gemini Advanced (Google)**](https://gemini.google.com/) – Google’s next-gen AI with multimodal capabilities and deep Search integration.  
+- [**Perplexity Pro**](https://www.perplexity.ai/) – AI-enhanced search engine offering real-time answers with citations.  
+- [**Mistral Large**](https://mistral.ai/) – Powerful open-weight European LLM excelling in reasoning and coding.  
+- [**Pi (Inflection AI)**](https://pi.ai/) – Empathetic conversational AI designed for “personal intelligence.”  
+- [**You.com**](https://you.com/) – Enterprise AI platform offering search, chat, and productivity tools.  
+- [**Quora Poe**](https://poe.com/) – Unified access to multiple AI models from one interface.
+
+---
+
+### Image & Video Generation
+
+- [**Midjourney v7**](https://www.midjourney.com/) – Premier text-to-image engine (note: official domain; adjust if needed).  
+- [**Adobe Firefly**](https://www.adobe.com/products/firefly.html) – Creative Cloud’s AI image and generative art suite.  
+- [**Google Veo 3**](https://gemini.google.com/subscriptions/) – Google’s advanced text-to-video model (accessible via Gemini plans).  
+- [**Runway Gen-4**](https://runwayml.com/) – Cinematic-quality AI video generation platform.  
+- [**Leonardo AI**](https://leonardo.ai/) – Ideal for stylized illustrations and game assets.  
+- [**CivitAI**](https://civitai.com/) – Community hub for Stable Diffusion model sharing.  
+- [**Magnific AI**](https://magnific.ai/) – Image upscaler and detail enhancer.  
+- [**Kaiber**](https://kaiber.ai/) – AI animation and music video creation tool.
+
+---
+
+### Coding & App Builders
+
+- [**GitHub Copilot**](https://github.com/features/copilot) – AI pair-programming tool integrated into GitHub.  
+- [**Cursor**](https://cursor.so/) – AI-first programming environment.  
+- [**Aider**](https://aider.ai/) – Terminal-based code assistant.  
+- [**Claude Code**](https://www.anthropic.com/claude) – Anthropic’s developer-targeted version of Claude.  
+- [**Windsurf (Codeium)**](https://codeium.com/) – AI-powered coding IDE.  
+- [**Zed**](https://zed.com/) – Fast collaborative editor with AI enhancements.  
+- [**Vibecode**](https://vibecode.ai/) – Build iOS apps via natural language (powered by modern LLMs).  
+- [**Replit Ghostwriter**](https://replit.com/) – AI tools for live online code collaboration.  
+- [**Sourcegraph Cody**](https://about.sourcegraph.com/cody) – AI assistant for navigating large codebases.  
+- [**Tabnine**](https://www.tabnine.com/) – Privacy-focused code autocompletion.
+
+---
+
+### Productivity & Knowledge
+
+- [**Notion AI**](https://www.notion.so/product/ai) – AI-enhanced workspace for writing and projects.  
+- [**Mem AI**](https://mem.ai/) – AI personal knowledge management.  
+- [**Recall**](https://www.recall.ai/) – Learning assistant with summaries and quizzes.  
+- [**Otter.ai**](https://otter.ai/) – Transcription and meeting summarization.  
+- [**Readwise Reader**](https://readwise.io/reader) – Improved reading with smart highlights and notes.  
+- [**Taskade AI**](https://www.taskade.com/) – Project management with AI workflows.  
+- [**Slite AI**](https://slite.com/) – Team docs with AI-powered summaries.  
+- [**Superhuman AI**](https://superhuman.com/) – Speedy, intelligent email management.
+
+---
+
+### Voice & Music
+
+- [**ElevenLabs v3**](https://elevenlabs.com/) – High-fidelity TTS supporting 70+ languages.  
+- [**ElevenLabs Music**](https://elevenlabs.com/) – Generative music with vocal control.  
+- [**Suno AI v3**](https://suno.ai/) – Rapid AI song generation.  
+- [**Aiva**](https://www.aiva.ai/) – AI for film and game music composition.  
+- [**Voicemod AI**](https://www.voicemod.net/) – Real-time AI voice modulation.  
+- [**Respeecher**](https://www.respeecher.com/) – Voice cloning for media.
+
+---
+
+### Automation & Integrations
+
+- [**n8n**](https://n8n.io/) – Open-source no-code workflow automation.  
+- [**Zapier AI Actions**](https://zapier.com/products/ai-actions) – Natural-language workflow automation in Zapier.  
+- [**Make (Integromat)**](https://www.make.com/) – Visual logic automation platform.  
+- [**Fathom**](https://fathom.video/) – AI assistant for meeting capture and summaries.  
+- [**Gumloop**](https://gumloop.com/) – AI workflow builder akin to Zapier.  
+- [**AgentGPT**](https://agentgpt.reworkd.ai/) – Deploy autonomous browser AI agents.  
+- [**Auto-GPT Next**](https://github.com/Significant-Gravitas/Auto-GPT) – Advanced autonomous AI task runners.
+
+---
+
+### Data, Research & Analysis
+
+- [**Perplexity Pro**](https://www.perplexity.ai/) – Premium AI-powered search with multiple model support.  
+- [**Elicit**](https://elicit.org/) – AI literature research assistant.  
+- [**Consensus**](https://consensus.app/) – AI summaries of academic research.  
+- [**Komo AI**](https://www.komo.ai/) – Private, personalized AI search.  
+- [**ChatDOC**](https://chatdoc.app/) – AI assistant for reading and querying PDFs.  
+- [**SciSpace**](https://typeset.io/) – AI-driven academic paper exploration.  
+- [**Tavily AI Search API**](https://tavily.com/) – Developer-friendly AI search services.
+
+---
+
+### Open-Source AI Models & Frameworks
+
+- [**Llama 3**](https://ai.facebook.com/blog/introducing-llama-3-family/) – Meta’s open-weight large language model series.  
+- [**Mistral 7B & Mixtral**](https://mistral.ai/) – Efficient, high-performance open LLMs.  
+- [**Phi-3 (Microsoft)**](https://huggingface.co/microsoft) – Compact, optimized LLMs.  
+- [**Stable Diffusion 3**](https://stablediffusionweb.com/) – Open-source image generation.  
+- [**ComfyUI**](https://comfyui.com/) – Node-based interface for Stable Diffusion workflows.  
+- [**Whisper**](https://openai.com/research/whisper) – OpenAI’s speech-to-text model.  
+- [**LangChain**](https://python.langchain.com/) – Framework for building LLM apps.  
+- [**Ollama**](https://ollama.ai/) – Local deployment of AI models with one-line setup.  
+- [**Open Interpreter**](https://github.com/openai/open-interpreter) – Natural-language interface for controlling your computer.
+
+---
+
+## Why These Tools?
+
+- **Freshness** – All entries are actively maintained as of mid-August 2025.  
+- **Breadth** – Covering creative, technical, productivity, research, and autonomous ecosystems.  
+- **Proven Performance** – Widely adopted with strong benchmarks and community traction.  
+- **Innovation** – Includes bleeding-edge tools like Veo 3, Vibecode, and ElevenLabs Music.
+
+---
+
+## Contributing
+
+Have a powerful tool missing here?  
+Submit a **Pull Request** or open an **Issue** — include name, category, short description, and recent activity proof (date or source).
+
+---
+
+## Related Lists
+
+- [**Awesome AI Tools**](https://github.com/mahseema/awesome-ai-tools) – A broad inventory of AI tools across domains.  
+- [**Awesome AI Coding Tools**](https://github.com/ai-for-developers/awesome-ai-coding-tools) – Focused on AI in software development.  
+- [**Top AI Directories**](https://github.com/best-of-ai/ai-directories) – Curated directories for discovering AI tools.
+
+---
+
+## License
+
+[MIT License](LICENSE)
+

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Submit a **Pull Request** or open an **Issue** — include name, category, short
 - [**AI For Developer**](https://aifordevelopers.org) - a curated ranked list of ai tools for developers
 - [**Awesome AI Coding Tools**](https://github.com/ai-for-developers/awesome-ai-coding-tools) – Focused on AI in software development.  
 - [**Top AI Directories**](https://github.com/best-of-ai/ai-directories) – Curated directories for discovering AI tools.
+- [**Awesome AI Startups**](https://github.com/nowork-studio/awesome-ai-startups) – A curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders.
 
 ---
 


### PR DESCRIPTION
Adds [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) to the **Related Lists** section.

It's a curated list of indie-built AI startups — bootstrapped, pre-seed, and angel-funded products only — covering 18 categories (AI Agents, Coding, Marketing, Audio/Voice, Image/Design, etc.) with ~440 entries.

Followed contributing conventions: matched the section's existing entry format and added at the bottom of the section.